### PR TITLE
Disable scrolling in the Editor

### DIFF
--- a/spyder/widgets/sourcecode/base.py
+++ b/spyder/widgets/sourcecode/base.py
@@ -1195,21 +1195,22 @@ class TextEditBaseWidget(QPlainTextEdit, BaseEditMixin):
     def wheelEvent(self, event):
         """Reimplemented to emit zoom in/out signals when Ctrl is pressed"""
         # This feature is disabled on MacOS, see Issue 1510
-        if sys.platform != 'darwin':
-            if event.modifiers() & Qt.ControlModifier:
-                if hasattr(event, 'angleDelta'):
-                    if event.angleDelta().y() < 0:
-                        self.zoom_out.emit()
-                    elif event.angleDelta().y() > 0:
-                        self.zoom_in.emit()
-                elif hasattr(event, 'delta'):
-                    if event.delta() < 0:
-                        self.zoom_out.emit()
-                    elif event.delta() > 0:
-                        self.zoom_in.emit()
-                return
-        QPlainTextEdit.wheelEvent(self, event)
-        self.highlight_current_cell()
+        #if sys.platform != 'darwin':
+        #    if event.modifiers() & Qt.ControlModifier:
+        #        if hasattr(event, 'angleDelta'):
+        #            if event.angleDelta().y() < 0:
+        #                self.zoom_out.emit()
+        #            elif event.angleDelta().y() > 0:
+        #                self.zoom_in.emit()
+        #        elif hasattr(event, 'delta'):
+        #            if event.delta() < 0:
+        #                self.zoom_out.emit()
+        #            elif event.delta() > 0:
+        #                self.zoom_in.emit()
+        #        return
+        #QPlainTextEdit.wheelEvent(self, event)
+        #self.highlight_current_cell()
+        pass
 
 
 class QtANSIEscapeCodeHandler(ANSIEscapeCodeHandler):

--- a/spyder/widgets/sourcecode/codeeditor.py
+++ b/spyder/widgets/sourcecode/codeeditor.py
@@ -363,6 +363,8 @@ class CodeEditor(TextEditBaseWidget):
         # functions or signals for objects not created from Python" in
         # Linux Ubuntu. See PR #5215.
         self.setVerticalScrollBar(QScrollBar())
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
         # Scrollbar flag area
         self.scrollflagarea = self.panels.register(ScrollFlagArea(self),
@@ -628,7 +630,7 @@ class CodeEditor(TextEditBaseWidget):
                      font=None, color_scheme=None, wrap=False, tab_mode=True,
                      intelligent_backspace=True, highlight_current_line=True,
                      highlight_current_cell=True, occurrence_highlighting=True,
-                     scrollflagarea=True, edge_line=True, edge_line_columns=(79,),
+                     scrollflagarea=False, edge_line=True, edge_line_columns=(79,),
                      codecompletion_auto=False, codecompletion_case=True,
                      codecompletion_enter=False, show_blanks=False,
                      calltips=None, go_to_definition=False,


### PR DESCRIPTION
@SelinaEmhardt, this pull request disables the mouse wheel from taking effect in the Editor, hides the vertical and horizontal scrollbars, and also hides a scroll area that we have next to the vertical scrollbar (which has a similar effect to the vertical scrollbar).

I hope this is everything you need for your experiment :-)